### PR TITLE
Avoid looking for the zeroth month for last months conda downloads

### DIFF
--- a/backend/src/fetchers/downloads_pepy.ts
+++ b/backend/src/fetchers/downloads_pepy.ts
@@ -23,8 +23,9 @@ export interface PePyResult {
 }
 
 const fetchDownloads = async (projectName: string) => {
-  let retries = 5;
-  let sleep_time = 1000;
+  let retries = 2;
+  // PePy API has a rate limit of 10 requests per minute
+  let sleep_time = 60_000;
   const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
   while (retries > 0) {
     try {

--- a/backend/src/fetchers/downloads_pepy.ts
+++ b/backend/src/fetchers/downloads_pepy.ts
@@ -23,22 +23,31 @@ export interface PePyResult {
 }
 
 const fetchDownloads = async (projectName: string) => {
-  try {
-    const response = await fetch(`https://api.pepy.tech/api/v2/projects/${projectName}`, {
-      headers: {
-        'X-Api-Key': process.env.PEPY_API_KEY!,
+  let retries = 5;
+  let sleep_time = 1000;
+  const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+  while (retries > 0) {
+    try {
+      const response = await fetch(`https://api.pepy.tech/api/v2/projects/${projectName}`, {
+        headers: {
+          'X-Api-Key': process.env.PEPY_API_KEY!,
+        }
+      });
+
+      if (!response.ok) {
+        console.error(`Error fetching download data for project ${projectName}: ${response.statusText}`);
+        console.error(`Retrying... in ${sleep_time}ms`);
+        retries--;
+        await sleep(sleep_time);
       }
-    });
 
-    if (!response.ok) {
-      console.error(`Error fetching download data for project ${projectName}: ${response.statusText}`);
-      return null;
+      return await response.json() as PePyResult;
+    } catch (error) {
+      console.error(`Error fetching download data for project ${projectName}:`, error);
+      console.error(`Retrying... in ${sleep_time}ms`);
+      retries--;
+      await sleep(sleep_time);
     }
-
-    return await response.json() as PePyResult;
-  } catch (error) {
-    console.error(`Error fetching download data for project ${projectName}:`, error);
-    return null;
   }
 };
 

--- a/backend/src/fetchers/downloads_pepy.ts
+++ b/backend/src/fetchers/downloads_pepy.ts
@@ -35,6 +35,11 @@ const fetchDownloads = async (projectName: string) => {
         }
       });
 
+      if (!response.ok && response.status === 404) {
+        console.error(`Project ${projectName} not found on PePy`);
+        return null;
+      }
+
       if (!response.ok) {
         console.error(`Error fetching download data for project ${projectName}: ${response.statusText}`);
         console.error(`Retrying... in ${sleep_time}ms`);
@@ -50,6 +55,8 @@ const fetchDownloads = async (projectName: string) => {
       await sleep(sleep_time);
     }
   }
+
+  return null;
 };
 
 const queryProjectsForRepositories = async (repositories: Repository[]) => {

--- a/backend/src/fetchers/downloads_pepy.ts
+++ b/backend/src/fetchers/downloads_pepy.ts
@@ -40,9 +40,9 @@ const fetchDownloads = async (projectName: string) => {
         return null;
       }
 
-      if (!response.ok) {
+      if (!response.ok && response.status === 429) {
         console.error(`Error fetching download data for project ${projectName}: ${response.statusText}`);
-        console.error(`Retrying... in ${sleep_time}ms`);
+        console.error(`Retrying in ${sleep_time}ms`);
         retries--;
         await sleep(sleep_time);
       }
@@ -50,7 +50,7 @@ const fetchDownloads = async (projectName: string) => {
       return await response.json() as PePyResult;
     } catch (error) {
       console.error(`Error fetching download data for project ${projectName}:`, error);
-      console.error(`Retrying... in ${sleep_time}ms`);
+      console.error(`Retrying in ${sleep_time}ms`);
       retries--;
       await sleep(sleep_time);
     }

--- a/backend/src/fetchers/fetch_parquet.ts
+++ b/backend/src/fetchers/fetch_parquet.ts
@@ -48,7 +48,7 @@ export const addCondaData = async (result: Result, octokit: CustomOctokit, confi
         fs.mkdirSync(baseDir);
     }
 
-    const currYear = new Date().getFullYear();
+    let currYear = new Date().getFullYear();
     let lastMonth = 1;
 
     for (let i = startYear; i <= currYear; i++) {
@@ -87,6 +87,11 @@ export const addCondaData = async (result: Result, octokit: CustomOctokit, confi
     const formattedString = packages.map((pkg) => `'${pkg}'`).join(',');
 
     const totalDownloads = await db.all(`SELECT pkg_name, SUM(counts)::INTEGER AS total FROM '${baseDir}/*.parquet' WHERE pkg_name IN (${formattedString}) GROUP BY pkg_name`);
+
+    if (lastMonth == 12) {
+        currYear -= 1;
+    }
+
     const lastMonthDownloads = await db.all(`SELECT pkg_name, SUM(counts)::INTEGER AS total FROM '${baseDir}/${currYear}-${String(lastMonth).padStart(2, '0')}.parquet' WHERE pkg_name IN (${formattedString}) GROUP BY pkg_name`);
 
     totalDownloads.forEach((row) => {

--- a/backend/src/fetchers/fetch_parquet.ts
+++ b/backend/src/fetchers/fetch_parquet.ts
@@ -75,6 +75,8 @@ export const addCondaData = async (result: Result, octokit: CustomOctokit, confi
                 // files to download and break the loop
                 if (!checkURLReq) {
                     lastMonth = j > 1 ? j - 1 : 12;
+                    // Make sure we break out of the outer loop as well
+                    i = currYear;
                     break;
                 } else {
                     await downloadParquetFile(url, fileName);

--- a/backend/src/fetchers/fetch_parquet.ts
+++ b/backend/src/fetchers/fetch_parquet.ts
@@ -76,7 +76,8 @@ export const addCondaData = async (result: Result, octokit: CustomOctokit, confi
                 if (!checkURLReq) {
                     lastMonth = j > 1 ? j - 1 : 12;
                     // Make sure we break out of the outer loop as well
-                    i = currYear;
+                    // Update teh current year to the last year we downloaded
+                    currYear = i;
                     break;
                 } else {
                     await downloadParquetFile(url, fileName);

--- a/backend/src/fetchers/fetch_parquet.ts
+++ b/backend/src/fetchers/fetch_parquet.ts
@@ -74,7 +74,7 @@ export const addCondaData = async (result: Result, octokit: CustomOctokit, confi
                 // If the URL does not exist, assume that there are no more
                 // files to download and break the loop
                 if (!checkURLReq) {
-                    lastMonth = j - 1;
+                    lastMonth = j > 1 ? j - 1 : 12;
                     break;
                 } else {
                     await downloadParquetFile(url, fileName);


### PR DESCRIPTION
Added extra logic to account for a new year.

pepy (used to track download numbers) has a 10 requests/minute max for free API users. Added a sleep to reset the count.