### PR TITLE
Add a max retries to fetching contributors

### DIFF
--- a/backend/src/fetchers/repository.ts
+++ b/backend/src/fetchers/repository.ts
@@ -98,7 +98,8 @@ export const addRepositoriesToResult: Fetcher = async (
   }
 
   const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
-  while (contributorsWaiting.length > 0) {
+  let maxRetries = 20;
+  while (contributorsWaiting.length > 0 && maxRetries > 0) {
     console.log(`Waiting for contributors data from ${contributorsWaiting.length} repositories to be ready`);
     await sleep(60000);
     const stillWaiting: Repository[] = []
@@ -122,6 +123,7 @@ export const addRepositoriesToResult: Fetcher = async (
     }
 
     contributorsWaiting = stillWaiting
+    maxRetries--;
   }
 
   return {


### PR DESCRIPTION
Currently, the contributor data for `qt-niu` can't be fetched for some reason. It continually returns a 202 status code, which typically indicates that a request is received but the data for the repo is not cached and will be available "soon".

For now I've just added a max retries (20) until we move on.