### PR TITLE
Freeze first column in dashboard tables.

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -2,6 +2,23 @@
 title: "Open Source Software Dashboard"
 format: dashboard
 ---
+```{=html}
+<script>
+document.addEventListener("DOMContentLoaded", () => {
+  if (!window.jQuery || !jQuery.fn || !jQuery.fn.dataTable) return;
+  const fix = () => {
+    jQuery.fn.dataTable.tables({ visible: true, api: true }).each(function () {
+      this.columns.adjust();
+      if (typeof this.fixedColumns === "function") {
+        this.fixedColumns().update();
+      }
+    });
+  };
+  window.addEventListener("load", fix);
+  jQuery('a[data-bs-toggle="tab"]').on("shown.bs.tab",fix);
+});
+</script>
+```
 
 ```{python}
 #| label: load-packages
@@ -45,23 +62,4 @@ print("Data last updated on:", niu_date.strftime("%A, %d. %B %Y %I:%M%p"))
 #| title: "BrainGlobe"
 itables.show(brainglobe_data, **table_options)
 print("Data last updated on:", brainglobe_date.strftime("%A, %d. %B %Y %I:%M%p"))
-```
-## Row
-
-```{=html}
-<script>
-document.addEventListener("DOMContentLoaded", () => {
-  if (!window.jQuery || !jQuery.fn || !jQuery.fn.dataTable) return;
-  const fix = () => {
-    jQuery.fn.dataTable.tables({ visible: true, api: true }).each(function () {
-      this.columns.adjust();
-      if (typeof this.fixedColumns === "function") {
-        this.fixedColumns().update();
-      }
-    });
-  };
-  window.addEventListener("load", fix);
-  jQuery('a[data-bs-toggle="tab"]').on("shown.bs.tab",fix);
-});
-</script>
 ```


### PR DESCRIPTION
## What this PR does
Freezes the first column in the dashboard tables so repository names remain visible when scrolling horizontally.

## Why
With many columns present, the repository name scrolled out of view, making it difficult to identify rows.

## How
- Enabled horizontal scrolling and FixedColumns for the first column
- Added a small JS hook to recalculate column widths after initial render and when switching tabs

## Verification
- Tested locally using "quarto preview"
- Horizontal scrolling works correctly
- First column remains fixed
- Switching tabs preserves alignment
- No browser console errors

Closes #84.