### PR TITLE
ensure CNAME is 'occupied'

### DIFF
--- a/.github/workflows/fetch_and_deploy.yml
+++ b/.github/workflows/fetch_and_deploy.yml
@@ -75,3 +75,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build
+          cname: dashboard.neuroinformatics.dev

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+dashboard.neuroinformatics.dev

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -7,7 +7,7 @@ execute:
 
 website:
   favicon: /img/logo_niu_light.png
-  site-url: "https://neuroinformatics.dev/dashboard/"
+  site-url: "https://dashboard.neuroinformatics.dev"
   navbar:
     left:
       - href: index.qmd


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
 Ensure the dashboard website claims the CNAME throughout.

## How has this PR been tested?
* Checked that `quarto render` locally copies the CNAME into the local build folder, which my AI assistant suggests is key for "claiming" it.
* Double-checked the action we use to deploy and this seems to [allow us to pass a `cname`](peaceiris/actions-gh-pages@v4) as an option

I don't really know how much of this is overkill (setting the `cname` in the workflow might be enough), but it won't hurt.
