### PR TITLE
Use correct PyPI project for oscar

### DIFF
--- a/oss_dashboard/brainglobe_legacy.json
+++ b/oss_dashboard/brainglobe_legacy.json
@@ -4,5 +4,6 @@
   "cellfinder-core": "cellfinder",
   "cellfinder-napari": "cellfinder",
   "brainreg-segment": "brainglobe-segmentation",
-  "brainreg-napari": "brainreg"
+  "brainreg-napari": "brainreg",
+  "oscar": "oscar-colony"
 }

--- a/oss_dashboard/brainglobe_legacy.json
+++ b/oss_dashboard/brainglobe_legacy.json
@@ -4,6 +4,5 @@
   "cellfinder-core": "cellfinder",
   "cellfinder-napari": "cellfinder",
   "brainreg-segment": "brainglobe-segmentation",
-  "brainreg-napari": "brainreg",
-  "oscar": "oscar-colony"
+  "brainreg-napari": "brainreg"
 }

--- a/oss_dashboard/fetchers/downloads_pepy.py
+++ b/oss_dashboard/fetchers/downloads_pepy.py
@@ -54,11 +54,11 @@ def _query_projects_for_repositories(
     """
     project_results = []
     num_requests = 0
-    pypi_project_overrides = load_package_mappings()
+    aliases = load_pypi_aliases()
 
     for repo in repositories:
         repo_name = repo["name"]
-        project_name = pypi_project_overrides.get(repo_name, repo_name)
+        project_name = aliases.get(repo_name, repo_name)
         retries = PEPY_MAX_RETRIES
 
         while retries > 0:

--- a/oss_dashboard/fetchers/downloads_pepy.py
+++ b/oss_dashboard/fetchers/downloads_pepy.py
@@ -14,7 +14,10 @@ from oss_dashboard.constants import (
     PEPY_RATE_LIMIT_REQUESTS,
     PEPY_RATE_LIMIT_SLEEP_SECONDS,
 )
-from oss_dashboard.fetchers.utils import query_repo_names
+from oss_dashboard.fetchers.utils import (
+    load_package_mappings,
+    query_repo_names,
+)
 from oss_dashboard.github_client import GitHubClient
 from oss_dashboard.models import Config, Result
 
@@ -51,10 +54,11 @@ def _query_projects_for_repositories(
     """
     project_results = []
     num_requests = 0
+    pypi_project_overrides = load_package_mappings()
 
     for repo in repositories:
         repo_name = repo["name"]
-        project_name = "oscar-colony" if repo_name == "oscar" else repo_name
+        project_name = pypi_project_overrides.get(repo_name, repo_name)
         retries = PEPY_MAX_RETRIES
 
         while retries > 0:

--- a/oss_dashboard/fetchers/downloads_pepy.py
+++ b/oss_dashboard/fetchers/downloads_pepy.py
@@ -54,6 +54,7 @@ def _query_projects_for_repositories(
 
     for repo in repositories:
         repo_name = repo["name"]
+        project_name = "oscar-colony" if repo_name == "oscar" else repo_name
         retries = PEPY_MAX_RETRIES
 
         while retries > 0:
@@ -71,7 +72,7 @@ def _query_projects_for_repositories(
                     num_requests = 0
 
                 num_requests += 1
-                response = _fetch_downloads(repo_name, api_key)
+                response = _fetch_downloads(project_name, api_key)
 
                 if response.status_code == HTTPStatus.NOT_FOUND:
                     logger.debug(

--- a/oss_dashboard/fetchers/downloads_pepy.py
+++ b/oss_dashboard/fetchers/downloads_pepy.py
@@ -15,7 +15,7 @@ from oss_dashboard.constants import (
     PEPY_RATE_LIMIT_SLEEP_SECONDS,
 )
 from oss_dashboard.fetchers.utils import (
-    load_package_mappings,
+    load_pypi_aliases,
     query_repo_names,
 )
 from oss_dashboard.github_client import GitHubClient

--- a/oss_dashboard/fetchers/utils.py
+++ b/oss_dashboard/fetchers/utils.py
@@ -11,13 +11,13 @@ from oss_dashboard.models import Config
 
 
 @lru_cache(maxsize=1)
-def load_package_mappings() -> dict[str, str]:
-    """Load package name overrides/mappings.
+def load_pypi_aliases() -> dict[str, str]:
+    """Load pypi aliases.
 
     Returns:
-        Dictionary of mappings.
+        Dictionary of pypi aliases.
     """
-    path = Path(__file__).parent.parent / "brainglobe_legacy.json"
+    path = Path(__file__).parent.parent / "pypi_aliases.json"
     if path.exists():
         with open(path) as f:
             return json.load(f)

--- a/oss_dashboard/fetchers/utils.py
+++ b/oss_dashboard/fetchers/utils.py
@@ -11,6 +11,20 @@ from oss_dashboard.models import Config
 
 
 @lru_cache(maxsize=1)
+def load_package_mappings() -> dict[str, str]:
+    """Load package name overrides/mappings.
+
+    Returns:
+        Dictionary of mappings.
+    """
+    path = Path(__file__).parent.parent / "brainglobe_legacy.json"
+    if path.exists():
+        with open(path) as f:
+            return json.load(f)
+    return {}
+
+
+@lru_cache(maxsize=1)
 def load_excluded_repos(config_dir: str | None = None) -> tuple[str, ...]:
     """Load the list of excluded repositories.
 

--- a/oss_dashboard/pypi_aliases.json
+++ b/oss_dashboard/pypi_aliases.json
@@ -1,0 +1,3 @@
+{
+    "oscar": "oscar-colony"
+}

--- a/oss_dashboard/pypi_aliases.json
+++ b/oss_dashboard/pypi_aliases.json
@@ -1,3 +1,3 @@
 {
-    "oscar": "oscar-colony"
+    "OSCaR": "oscar-colony"
 }


### PR DESCRIPTION
## Summary

This PR fixes the PyPI download statistics lookup for the `oscar` repository.

The GitHub repository is named `oscar`, but its corresponding PyPI project is `oscar-colony`. Previously, the dashboard queried PePy using the GitHub repository name (`oscar`), resulting in incorrect download statistics.

## Changes

- Map the `oscar` GitHub repository to the `oscar-colony` PyPI project.
- Use the mapped project name when querying the PePy API.
- Preserve the GitHub repository name throughout the dashboard.

## Result

The `oscar` repository now correctly displays download statistics from the `oscar-colony` PyPI project, while all other repositories continue to behave as before.

Fixes #104