### PR TITLE
Add GitHub repository link to dashboard navbar

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -11,7 +11,7 @@ website:
   navbar:
     right:
       - href: https://github.com/neuroinformatics-unit/dashboard
-        text: GitHub
+        icon: github
         target: _blank
     left:
       - href: index.qmd

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -9,6 +9,10 @@ website:
   favicon: /img/logo_niu_light.png
   site-url: "https://dashboard.neuroinformatics.dev"
   navbar:
+    right:
+      - href: https://github.com/neuroinformatics-unit/dashboard
+        text: GitHub
+        target: _blank
     left:
       - href: index.qmd
         text: Dashboard


### PR DESCRIPTION
## Summary

This PR adds a GitHub repository link to the dashboard navigation bar, making it easier for users to quickly access the repository and raise issues.

## Changes

- Added a GitHub link to the right side of the dashboard navbar.
- Configured the link to open the dashboard repository.

## Result

Users can now directly navigate to the project's GitHub repository from the dashboard without manually searching for it.

Fixes #108 