### PR TITLE
Sync the dark mode toggle for itables

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -4,6 +4,22 @@ format: dashboard
 ---
 ```{=html}
 <script>
+// DataTables (dt_for_itables) gates all of its dark styling on `html.dark`,
+// while Quarto only sets `body.quarto-dark`. Mirror the flag onto <html> so
+// the DataTables dark theme follows Quarto's light/dark toggle.
+(() => {
+  const sync = () =>
+    document.documentElement.classList.toggle(
+      "dark",
+      document.body.classList.contains("quarto-dark")
+    );
+  sync();
+  new MutationObserver(sync).observe(document.body, {
+    attributes: true,
+    attributeFilter: ["class"],
+  });
+})();
+
 document.addEventListener("DOMContentLoaded", () => {
   if (!window.jQuery || !jQuery.fn || !jQuery.fn.dataTable) return;
   const fix = () => {

--- a/niu-dark.scss
+++ b/niu-dark.scss
@@ -8,11 +8,10 @@ body.quarto-dark .nav-tabs .nav-link {
     color: #FFFFFF;
 }
 
-body.quarto-dark table.dataTable thead tr>.dtfc-fixed-start,
-body.quarto-dark table.dataTable thead tr>.dtfc-fixed-end,
-body.quarto-dark table.dataTable tfoot tr>.dtfc-fixed-start,
-body.quarto-dark table.dataTable tfoot tr>.dtfc-fixed-end,
-body.quarto-dark table.dataTable tbody tr>.dtfc-fixed-start,
-body.quarto-dark table.dataTable tbody tr>.dtfc-fixed-end {
-    background-color: #1E1E1E;
+body.quarto-dark {
+    --dt-html-background: #1E1E1E;
+    --itables-dark-color: #FFFFFF;
+    --dtfc_background: #1E1E1E;
+    --dtfc-thead-cell_background: #1E1E1E;
+    --dtfc-tbody-cell_background: #1E1E1E;
 }


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/neuroinformatics-unit/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
See #111 

**What does this PR do?**
Syncs the toggle between `body.quarto-dark` and `html.dark`

## References
Closes #111 


## How has this PR been tested?
Built locally, toggled dark mode on and off.

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
No

## Checklist:

- [x] The code has been tested locally
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
